### PR TITLE
Fix link to examples in scripts/README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,4 +32,4 @@ uv run torchrun --standalone --nnodes=1 --nproc_per_node=8 \
 ```
 
 ### Evaluation
-See [examples](examples/README.md) for details about evaluation in LIBERO and other simulation environments.
+See [examples](../examples/README.md) for details about evaluation in LIBERO and other simulation environments.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix the examples README link in scripts/README.md for the evaluation section.